### PR TITLE
feat: implement mapping configuration for Material, City and Department using MapStruct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
 			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -102,25 +107,20 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
 				<configuration>
 					<annotationProcessorPaths>
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>1.18.30</version>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.5.5.Final</version>
 						</path>
 					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml~
+++ b/pom.xml~
@@ -81,19 +81,24 @@
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-api</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-impl</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-jackson</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version>
 		</dependency>
 	</dependencies>
 
@@ -121,6 +126,20 @@
 							<artifactId>lombok</artifactId>
 						</exclude>
 					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>1.5.5.Final</version>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/MapperConstants.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/MapperConstants.java
@@ -1,0 +1,13 @@
+package com.sysman.prueba_tecnica_sysman_backend.constants;
+
+public class MapperConstants {
+
+    private MapperConstants() {}
+
+    public static final String ID = "id";
+    public static final String CITY_CODE = "cityCode";
+    public static final String CITY = "city";
+    public static final  String SPRING = "spring";
+    public static final  String MAP_CITY_FROM_CODE = "mapCityFromCode";
+
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/CityMapper.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/CityMapper.java
@@ -1,0 +1,17 @@
+package com.sysman.prueba_tecnica_sysman_backend.mapper;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.MapperConstants;
+import com.sysman.prueba_tecnica_sysman_backend.dto.CityDTO;
+import com.sysman.prueba_tecnica_sysman_backend.entity.City;
+import com.sysman.prueba_tecnica_sysman_backend.entity.Department;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.springframework.stereotype.Component;
+
+@Component
+@Mapper(componentModel = MapperConstants.SPRING, uses = Department.class)
+public interface CityMapper {
+
+    CityDTO toDto(City city);
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/CityMapper.java~
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/CityMapper.java~
@@ -1,0 +1,18 @@
+package com.sysman.prueba_tecnica_sysman_backend.mapper;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.MapperConstants;
+import com.sysman.prueba_tecnica_sysman_backend.dto.CityDTO;
+import com.sysman.prueba_tecnica_sysman_backend.entity.City;
+import com.sysman.prueba_tecnica_sysman_backend.entity.Department;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.springframework.stereotype.Component;
+
+@Component
+@Mapper(componentModel = MapperConstants.SPRING, uses = Department.class)
+public interface CityMapper {
+
+    @Mapping(source = MapperConstants.DEPARTMENT, target = MapperConstants.DEPARTMENT)
+    CityDTO toDto(City city);
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/DepartmentMapper.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/DepartmentMapper.java
@@ -1,0 +1,14 @@
+package com.sysman.prueba_tecnica_sysman_backend.mapper;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.MapperConstants;
+import com.sysman.prueba_tecnica_sysman_backend.dto.DepartmentDTO;
+import com.sysman.prueba_tecnica_sysman_backend.entity.Department;
+import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
+
+@Component
+@Mapper(componentModel = MapperConstants.SPRING)
+public interface DepartmentMapper {
+
+    DepartmentDTO toDto(Department department);
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/DepartmentMapper.java~
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/DepartmentMapper.java~
@@ -1,0 +1,12 @@
+package com.sysman.prueba_tecnica_sysman_backend.mapper;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.MapperConstants;
+import org.mapstruct.Mapper;
+import org.springframework.stereotype.Component;
+
+@Component
+@Mapper(componentModel = MapperConstants.SPRING)
+public interface DepartmentMapper {
+
+    
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/MaterialMapper.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/MaterialMapper.java
@@ -1,0 +1,31 @@
+package com.sysman.prueba_tecnica_sysman_backend.mapper;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.MapperConstants;
+import com.sysman.prueba_tecnica_sysman_backend.dto.MaterialRequestDTO;
+import com.sysman.prueba_tecnica_sysman_backend.dto.MaterialResponseDTO;
+import com.sysman.prueba_tecnica_sysman_backend.entity.City;
+import com.sysman.prueba_tecnica_sysman_backend.entity.Material;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.springframework.stereotype.Component;
+
+@Component
+@Mapper(componentModel = MapperConstants.SPRING)
+public interface MaterialMapper {
+
+    @Mapping(target = MapperConstants.ID, ignore = true)
+    @Mapping(target = MapperConstants.CITY, source = MapperConstants.CITY_CODE, qualifiedByName = MapperConstants.MAP_CITY_FROM_CODE)
+    Material toEntity(MaterialRequestDTO dto);
+
+    @Mapping(target = MapperConstants.CITY, source = MapperConstants.CITY)
+    MaterialResponseDTO toDto(Material entity);
+
+    @Named(MapperConstants.MAP_CITY_FROM_CODE)
+    default City mapCityFromCode(String cityCode) {
+        if (cityCode == null) return null;
+        City city = new City();
+        city.setCode(cityCode);
+        return city;
+    }
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/MaterialMapper.java~
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/MaterialMapper.java~
@@ -1,0 +1,31 @@
+package com.sysman.prueba_tecnica_sysman_backend.mapper;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.MapperConstants;
+import com.sysman.prueba_tecnica_sysman_backend.dto.MaterialRequestDTO;
+import com.sysman.prueba_tecnica_sysman_backend.dto.MaterialResponseDTO;
+import com.sysman.prueba_tecnica_sysman_backend.entity.City;
+import com.sysman.prueba_tecnica_sysman_backend.entity.Material;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.springframework.stereotype.Component;
+
+@Component
+@Mapper(componentModel = MapperConstants.SPRING)
+public interface MaterialMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = MapperConstants.CITY, source = MapperConstants.CITY_CODE, qualifiedByName = MapperConstants.MAP_CITY_FROM_CODE)
+    Material toEntity(MaterialRequestDTO dto);
+
+    @Mapping(target = MapperConstants.CITY, source = MapperConstants.CITY)
+    MaterialResponseDTO toDto(Material entity);
+
+    @Named(MapperConstants.MAP_CITY_FROM_CODE)
+    default City mapCityFromCode(String cityCode) {
+        if (cityCode == null) return null;
+        City city = new City();
+        city.setCode(cityCode);
+        return city;
+    }
+}


### PR DESCRIPTION
Se implementan los mapeadores con MapStruct para Material, City y Department.
Incluye uso de constantes, manejo de relaciones anidadas, y validaciones de compilación.
Configuración finalizada y validada en pom.xml.