### PR TITLE
feat: add global exception handling with RestControllerAdvice

### DIFF
--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/ExceptionMessages.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/ExceptionMessages.java
@@ -2,8 +2,10 @@ package com.sysman.prueba_tecnica_sysman_backend.constants;
 
 public class ExceptionMessages {
 
+    public static  final  String MESSAGE = "message";
     public static final String MATERIAL_NOT_FOUND = "Material not found with id: %s";
     public static final String INVALID_DATES = "Purchase date must be before sale date";
+    public static final String UNEXPECTED_ERROR = "An unexpected error occurred on the server.";
 
     private ExceptionMessages() {}
 }

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/LogMessages.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/LogMessages.java
@@ -7,4 +7,9 @@ public class LogMessages {
     public static final String CREATING_MATERIAL = "Creating material with type: {}";
     public static final String UPDATING_MATERIAL = "Updating material with id: {}";
     public static final String DELETING_MATERIAL = "Deleting material with id: {}";
+
+    public static final String MATERIAL_NOT_FOUND = "Material not found: {}";
+    public static final String INVALID_MATERIAL_DATES = "Invalid material dates: {}";
+    public static final String UNEXPECTED_ERROR = "Unexpected error: {}";
+
 }

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,69 @@
+package com.sysman.prueba_tecnica_sysman_backend.exception;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.ExceptionMessages;
+import com.sysman.prueba_tecnica_sysman_backend.constants.LogMessages;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(MaterialNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleMaterialNotFound(MaterialNotFoundException ex) {
+
+        log.warn(LogMessages.MATERIAL_NOT_FOUND, ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Collections.singletonMap(ExceptionMessages.MESSAGE, ex.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidMaterialDatesException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidMaterialDates(InvalidMaterialDatesException ex) {
+
+        log.warn(LogMessages.INVALID_MATERIAL_DATES, ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Collections.singletonMap(ExceptionMessages.MESSAGE, ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationException(MethodArgumentNotValidException ex) {
+
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        return  ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Map<String, String>> handleConstraintViolationException(ConstraintViolationException ex) {
+
+        Map<String, String> errors = new HashMap<>();
+        for (ConstraintViolation<?> violation : ex.getConstraintViolations()) {
+            String[] pathElements = violation.getPropertyPath().toString().split("\\.");
+            String paramName = pathElements[pathElements.length - 1];
+            String message = violation.getMessage();
+            errors.put(paramName, message);
+        }
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGenericException(Exception ex) {
+        log.error(LogMessages.UNEXPECTED_ERROR, ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Collections.singletonMap(ExceptionMessages.MESSAGE, ExceptionMessages.UNEXPECTED_ERROR));
+    }
+}


### PR DESCRIPTION
Se implementó el manejo centralizado de excepciones utilizando @RestControllerAdvice para capturar errores de validación, de negocio y de ejecución con respuestas consistentes y mensajes claros.