### PR TITLE
feat: add endpoints to get departments and cities with optional filtering

### DIFF
--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/CityConstants.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/CityConstants.java
@@ -1,0 +1,13 @@
+package com.sysman.prueba_tecnica_sysman_backend.constants;
+
+public class CityConstants {
+
+    public static final String CODE_DESCRIPTION = "Código de la ciudad según el DANE";
+    public static final String CODE_EXAMPLE = "05001";
+    public static final String NAME_DESCRIPTION = "Nombre de la ciudad";
+    public static final String NAME_EXAMPLE = "Medellín";
+    public static final String DEPARTMENT_CODE_DESCRIPTION = "Código del departamento al que pertenece";
+    public static final String DEPARTMENT_CODE_EXAMPLE = "05";
+
+    private CityConstants() {}
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/DepartmentConstants.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/DepartmentConstants.java
@@ -1,0 +1,11 @@
+package com.sysman.prueba_tecnica_sysman_backend.constants;
+
+public class DepartmentConstants {
+
+    public static final String CODE_DESCRIPTION = "Código del departamento según el DANE";
+    public static final String CODE_EXAMPLE = "05";
+    public static final String NAME_DESCRIPTION = "Nombre del departamento";
+    public static final String NAME_EXAMPLE = "Antioquia";
+
+    private DepartmentConstants() {}
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/LocationConstants.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/constants/LocationConstants.java
@@ -1,0 +1,22 @@
+package com.sysman.prueba_tecnica_sysman_backend.constants;
+
+public class LocationConstants {
+
+    public static final String PATH = "/api/v1/locations";
+
+    public static final String TAG = "Ubicaciones";
+    public static final String TAG_DESCRIPTION = "Controlador para gestión de ubicaciones";
+
+    public static final String DEPARTMENTS_SUMMARY = "Listar todos los departamentos";
+    public static final String DEPARTMENTS_DESC = "Obtiene una lista de todos los departamentos registrados en el sistema.";
+
+    public static final String CITIES_SUMMARY = "Listar todas las ciudades o filtrar por código de departamento";
+    public static final String CITIES_DESC = "Obtiene todas las ciudades o aquellas que pertenecen al departamento indicado por su código.";
+
+    public static final String PARAM_DEPARTMENT_CODE = "Código del departamento para filtrar las ciudades (opcional)";
+
+    public static final String DEPARTMENTS_RESPONSE_DESCRIPTION = "Departamentos obtenidos exitosamente";
+    public static final String CITIES_RESPONSE_DESCRIPTION = "Ciudades obtenidas exitosamente";
+
+    private LocationConstants() {}
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/controller/LocationController.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/controller/LocationController.java
@@ -1,0 +1,49 @@
+package com.sysman.prueba_tecnica_sysman_backend.controller;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.LocationConstants;
+import com.sysman.prueba_tecnica_sysman_backend.dto.CityResponseDTO;
+import com.sysman.prueba_tecnica_sysman_backend.dto.DepartmentResponseDTO;
+import com.sysman.prueba_tecnica_sysman_backend.service.LocationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(LocationConstants.PATH)
+@RequiredArgsConstructor
+@Tag(name = LocationConstants.TAG, description = LocationConstants.TAG_DESCRIPTION)
+@PreAuthorize("isAuthenticated()")
+public class LocationController {
+
+    private final LocationService locationService;
+
+    @Operation(
+            summary = LocationConstants.DEPARTMENTS_SUMMARY,
+            description = LocationConstants.DEPARTMENTS_DESC
+    )
+    @ApiResponse(responseCode = "200", description = LocationConstants.DEPARTMENTS_RESPONSE_DESCRIPTION)
+    @GetMapping("/departments")
+    public ResponseEntity<List<DepartmentResponseDTO>> getAllDepartments() {
+        return ResponseEntity.ok(locationService.getAllDepartments());
+    }
+
+    @Operation(
+            summary = LocationConstants.CITIES_SUMMARY,
+            description = LocationConstants.CITIES_DESC
+    )
+    @ApiResponse(responseCode = "200", description = LocationConstants.CITIES_RESPONSE_DESCRIPTION)
+    @GetMapping("/cities")
+    public ResponseEntity<List<CityResponseDTO>> getAllCities(
+            @Parameter(description = LocationConstants.PARAM_DEPARTMENT_CODE)
+            @RequestParam(required = false) String departmentCode
+    ) {
+        return ResponseEntity.ok(locationService.getAllCitiesByDepartment(departmentCode));
+    }
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/dto/CityResponseDTO.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/dto/CityResponseDTO.java
@@ -1,0 +1,21 @@
+package com.sysman.prueba_tecnica_sysman_backend.dto;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.CityConstants;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class CityResponseDTO {
+    @Schema(description = CityConstants.CODE_DESCRIPTION, example = CityConstants.CODE_EXAMPLE)
+    private String code;
+
+    @Schema(description = CityConstants.NAME_DESCRIPTION, example = CityConstants.NAME_EXAMPLE)
+    private String name;
+
+    @Schema(description = CityConstants.DEPARTMENT_CODE_DESCRIPTION, example = CityConstants.DEPARTMENT_CODE_EXAMPLE)
+    private String departmentCode;
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/dto/DepartmentResponseDTO.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/dto/DepartmentResponseDTO.java
@@ -1,0 +1,18 @@
+package com.sysman.prueba_tecnica_sysman_backend.dto;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.DepartmentConstants;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class DepartmentResponseDTO {
+    @Schema(description = DepartmentConstants.CODE_DESCRIPTION, example = DepartmentConstants.CODE_EXAMPLE)
+    private String code;
+
+    @Schema(description = DepartmentConstants.NAME_DESCRIPTION, example = DepartmentConstants.NAME_EXAMPLE)
+    private String name;
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/LocationMapper.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/mapper/LocationMapper.java
@@ -1,0 +1,20 @@
+package com.sysman.prueba_tecnica_sysman_backend.mapper;
+
+import com.sysman.prueba_tecnica_sysman_backend.constants.MapperConstants;
+import com.sysman.prueba_tecnica_sysman_backend.dto.CityResponseDTO;
+import com.sysman.prueba_tecnica_sysman_backend.dto.DepartmentResponseDTO;
+import com.sysman.prueba_tecnica_sysman_backend.entity.City;
+import com.sysman.prueba_tecnica_sysman_backend.entity.Department;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.springframework.stereotype.Component;
+
+@Component
+@Mapper(componentModel = MapperConstants.SPRING)
+public interface LocationMapper {
+
+    @Mapping(source = "department.code", target = "departmentCode")
+    CityResponseDTO toCityDto(City city);
+
+    DepartmentResponseDTO toDepartmentDto(Department department);
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/repository/CityRepository.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/repository/CityRepository.java
@@ -6,9 +6,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface CityRepository extends JpaRepository<City, String> {
 
     Optional<Object> findByCode(@Size(max = NumericConstants.CODE_MAX_LENGTH) @NotBlank String code);
+
+    List<City> findByDepartment_Code(String departmentCode);
 }

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/service/LocationService.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/service/LocationService.java
@@ -1,0 +1,11 @@
+package com.sysman.prueba_tecnica_sysman_backend.service;
+
+import com.sysman.prueba_tecnica_sysman_backend.dto.CityResponseDTO;
+import com.sysman.prueba_tecnica_sysman_backend.dto.DepartmentResponseDTO;
+
+import java.util.List;
+
+public interface LocationService {
+    List<DepartmentResponseDTO> getAllDepartments();
+    List<CityResponseDTO> getAllCitiesByDepartment(String departmentCode);
+}

--- a/src/main/java/com/sysman/prueba_tecnica_sysman_backend/service/LocationServiceImpl.java
+++ b/src/main/java/com/sysman/prueba_tecnica_sysman_backend/service/LocationServiceImpl.java
@@ -1,0 +1,42 @@
+package com.sysman.prueba_tecnica_sysman_backend.service;
+
+import com.sysman.prueba_tecnica_sysman_backend.dto.CityResponseDTO;
+import com.sysman.prueba_tecnica_sysman_backend.dto.DepartmentResponseDTO;
+import com.sysman.prueba_tecnica_sysman_backend.mapper.LocationMapper;
+import com.sysman.prueba_tecnica_sysman_backend.repository.CityRepository;
+import com.sysman.prueba_tecnica_sysman_backend.repository.DepartmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LocationServiceImpl implements LocationService {
+
+    private final DepartmentRepository departmentRepository;
+    private final CityRepository cityRepository;
+    private final LocationMapper mapper;
+
+    @Override
+    public List<DepartmentResponseDTO> getAllDepartments() {
+        return departmentRepository.findAll()
+                .stream()
+                .map(mapper::toDepartmentDto)
+                .toList();
+    }
+
+    @Override
+    public List<CityResponseDTO> getAllCitiesByDepartment(String departmentCode) {
+        if (departmentCode != null) {
+            return cityRepository.findByDepartment_Code(departmentCode)
+                    .stream()
+                    .map(mapper::toCityDto)
+                    .toList();
+        }
+        return cityRepository.findAll()
+                .stream()
+                .map(mapper::toCityDto)
+                .toList();
+    }
+}


### PR DESCRIPTION
Agrega los endpoints para consultar departamentos y ciudades, incluyendo filtro opcional por código de departamento, con su respectiva documentación y mapeadores.